### PR TITLE
fix(db): validate MONGODB_URI environment variable on startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# MongoDB Connection URI
+# Get this from your MongoDB Atlas cluster or local MongoDB instance
+MONGODB_URI=mongodb://localhost:27017/university
+
+# Example for MongoDB Atlas:
+# MONGODB_URI=mongodb+srv://username:password@cluster.mongodb.net/university?retryWrites=true&w=majority

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/lib/db/db.ts
+++ b/lib/db/db.ts
@@ -3,6 +3,14 @@ import mongoose from "mongoose";
 const MONGODB_URI = process.env.MONGODB_URI;
 
 const connect = async () => {
+  // Validate environment variable on startup
+  if (!MONGODB_URI) {
+    throw new Error(
+      "MONGODB_URI environment variable is not defined. " +
+        "Please define it in your .env.local or environment configuration."
+    );
+  }
+
   const connectionState = mongoose.connection.readyState;
   if (connectionState === 1) {
     console.log("DB is already connected");
@@ -14,7 +22,7 @@ const connect = async () => {
     return;
   }
   try {
-    await mongoose.connect(MONGODB_URI!, {
+    await mongoose.connect(MONGODB_URI, {
       dbName: "university",
       bufferCommands: true,
     });


### PR DESCRIPTION
## Description

This PR fixes issue #5 by adding validation for the `MONGODB_URI` environment variable before attempting to connect to MongoDB.

## Changes

- **lib/db/db.ts**: Added environment variable validation check
  - Validates `MONGODB_URI` is defined before connecting
  - Throws a clear, helpful error message if undefined
  - Removed unsafe non-null assertion operator (`!`)

- **.env.example**: Added example environment variable file
  - Documents the required `MONGODB_URI` variable
  - Provides example connection strings for local and MongoDB Atlas

- **.gitignore**: Updated to allow `.env.example` file
  - Changed `.env*` pattern to exclude `.env.example` from being ignored
  - This allows the example file to be committed for documentation

## Problem

Previously, if `MONGODB_URI` was not defined in the environment:
- Mongoose would attempt to connect with an undefined URI
- This could cause silent failures or unclear errors
- Users would not know what was wrong

## Solution

Now, the code validates the environment variable at startup:
- If `MONGODB_URI` is missing, a clear error is thrown immediately
- The error message explains exactly what needs to be configured
- This prevents confusion and helps users set up the database correctly

## Testing

The code change is minimal and focuses on error handling:
- Type-safe validation before MongoDB connection
- Clear error message for missing configuration
- Follows project coding standards

Closes #5