### PR TITLE
feat: Add .env.example file for new contributors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# MongoDB Connection URI
+MONGODB_URI=
+
+# Admin API Key for administrative operations
+ADMIN_API_KEY=


### PR DESCRIPTION
## Summary
This PR adds a `.env.example` file to help new contributors understand which environment variables are required to run the project.

## Changes
Added `.env.example` file with placeholders for:
- `MONGODB_URI`: MongoDB connection string
- `ADMIN_API_KEY`: Admin API key for administrative operations

## Why This Is Needed
New contributors often struggle to set up the project without knowing which environment variables are required. This file serves as a template that they can copy to `.env` and fill in their actual values.

## Notes
The file is added with `-f` flag since `.gitignore` contains `.env*` pattern that would normally ignore it. This is acceptable for `.env.example` as it only contains placeholders, not actual credentials.

## Testing
- File syntax is correct
- Follows standard .env format
- Contains clear comments for each variable

## Related Issue
Closes #9

## Checklist
- [x] Added MONGODB_URI placeholder
- [x] Added ADMIN_API_KEY placeholder
- [x] Added helpful comments
- [x] File follows standard .env format