### PR TITLE
fix: add missing type exports and imports for selectType and params

### DIFF
--- a/lib/Scraping/scrape.ts
+++ b/lib/Scraping/scrape.ts
@@ -1,5 +1,6 @@
 import { Model } from "mongoose";
 import connect from "../db/db";
+import { selectType, params } from "./scrape_types";
 
 /**
  * Fetches data from the BAU courses API (https://app2.bau.edu.jo:7799/courses/index.jsp)

--- a/lib/Scraping/scrape_types.ts
+++ b/lib/Scraping/scrape_types.ts
@@ -1,7 +1,7 @@
-type selectType =
+export type selectType =
   | { name: string; id: string }
   | { no: string; name: string; hours: string };
-type params = {
+export type params = {
   data: string;
   params: department | course;
 } | null;


### PR DESCRIPTION
## Summary

Fixes #4

- **Problem:** `selectType` and `params` types are defined in `scrape_types.ts` but not exported, causing TypeScript to fail when `scrape.ts` uses them without importing.
- **What changed:**
  - Added `export` to `selectType` and `params` types in `scrape_types.ts`
  - Added `import { selectType, params }` to `scrape.ts`
- **What did NOT change:** No logic changes, types unchanged.

Rebased onto `feat/scraper` as requested by @MoMaimon.