### PR TITLE
Implement College Blacklisting and Enhance Scraping Robustness

### DIFF
--- a/lib/Scraping/scrape.ts
+++ b/lib/Scraping/scrape.ts
@@ -80,7 +80,8 @@ export const fetchAndSave = async <T>(
   const data = await fetchData<T>(rmiMethod, paramList);
   await connect();
 
-  const bulk = data.map(buildUpsertDoc);
+  const bulk = data.map(buildUpsertDoc).filter(Boolean);
+
   if (bulk.length > 0) {
     const result = await model.bulkWrite(bulk);
     console.log(

--- a/lib/Scraping/scrape_service.ts
+++ b/lib/Scraping/scrape_service.ts
@@ -110,15 +110,22 @@ export const syncDegrees = async () => {
  * @returns {Promise<void>}
  */
 export const syncColleges = async () => {
+  const blackList = [14, 12];
   await fetchAndSave<CollegeApiResponse>(
     { rmiMethod: "getColleges", model: College },
-    (college) => ({
-      updateOne: {
-        filter: { _id: college.id },
-        update: { $set: { name: college.name } },
-        upsert: true,
-      },
-    }),
+    (college) => {
+      if (blackList.includes(Number(college.id))) {
+        console.log(`Skipping blacklisted college: ${college.name}`);
+        return null;
+      }
+      return {
+        updateOne: {
+          filter: { _id: college.id },
+          update: { $set: { name: college.name } },
+          upsert: true,
+        },
+      };
+    },
   );
 };
 


### PR DESCRIPTION
## Summary
This PR introduces a blacklisting mechanism for the college synchronization process and improves the core scraping utility to handle null or filtered-out document transformations. These changes ensure that specific institutions (IDs 12 and 14) are excluded from the database sync while preventing potential errors during bulk write operations when items are skipped.

## Changes Included
### `lib/Scraping/scrape.ts`
- Added filtering to bulk operations: Updated `fetchAndSave` to filter out falsy values (using `.filter(Boolean)`) after the mapping stage. This allows individual document builders to return `null` if an item should be skipped without breaking the `bulkWrite` execution.

### `lib/Scraping/scrape_service.ts`

- Introduced `blackList` for Colleges: Defined a list of forbidden IDs `[14, 12]` within the `syncColleges` function.
- Conditional Upsert Logic: Modified the `syncColleges` mapping function to check if a college's ID is in the blacklist.
   - If blacklisted, the system logs a message and returns `null`.
   - Otherwise, it proceeds with the standard `updateOne` upsert document.
 
## Impact

- Data Quality: Prevents unwanted or test data from designated college IDs from entering the production database.
- Stability: The addition of `.filter(Boolean)` in the generic scraping logic makes the utility more flexible for future use cases where conditional syncing is required.

closes #22 