### PR TITLE
feat(auth): Add API key authentication for scrape API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ MONGODB_URI=mongodb://localhost:27017/university
 
 # Example for MongoDB Atlas:
 # MONGODB_URI=mongodb+srv://username:password@cluster.mongodb.net/university?retryWrites=true&w=majority
+
+ADMIN_API_KEY=

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function proxy(request: NextRequest) {
+  if (request.method === "POST") {
+    const authHeader = request.headers.get("authorization");
+    const expectedKey = process.env.ADMIN_API_KEY;
+
+    if (!authHeader || authHeader !== `Bearer ${expectedKey}`) {
+      return NextResponse.json(
+        { error: "Unauthorized access: Invalid or missing Admin API Key" },
+        { status: 401 },
+      );
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/api/scrape/:path*",
+};


### PR DESCRIPTION
## Summary

This PR introduces several improvements to the scraping service and API security.  introduction of a middleware-based proxy to secure scraping endpoints via an Admin API Key.


## Changes Included

###  Security & Configuration
* **Added `ADMIN_API_KEY` to `.env.example`**: Defined a new environment variable required for authenticating administrative scraping requests.
* **New API Proxy Middleware**: Created `proxy.ts` to intercept `POST` requests to `/api/scrape/*`. It validates the `Authorization` bearer token against the environment's `ADMIN_API_KEY`.


## Refs
closes: #2 